### PR TITLE
Fix crash from invalid entrypoint

### DIFF
--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -20,9 +20,7 @@
             "license": "MIT"
 		},
 		"intermediate_mappings": "net.fabricmc:intermediary",
-		"entrypoints": {
-			"init": "dev.pixirora.janerator.Janerator"
-		},
+		"entrypoints": {},
 		"depends": [
 			{
 				"id": "quilt_loader",


### PR DESCRIPTION
Fixes janerator crashing in combination with qsl when it tries to execute this entrypoint, even though it's a regular class.